### PR TITLE
Remove [OUTPUT] tag when debugging. Cleanup.

### DIFF
--- a/src/CPipe.cpp
+++ b/src/CPipe.cpp
@@ -246,7 +246,7 @@ void CPipe::startOutput() {
 	std::string cmd;
 	do {
 		if("" != (cmd = dequeueOutputMessage(false))) {
-			std::cout << (debugMode ? "[OUTPUT] " : "" ) << cmd << std::endl;
+			std::cout << cmd << std::endl;
 		}
 	} while(isRunning);
 }
@@ -375,14 +375,12 @@ void CPipe::d(const std::string message) {
 
 std::string CPipe::readNext(bool readToEnd) {
 	std::string str;
-
-	// skip any whitespace at the beginning of the input
-	std::cin >> std::skipws;
-
+	
 	if(readToEnd) {
 		std::getline(std::cin, str);
+		str = ltrim(str);
 	} else {
-		std::cin >> str;
+		std::cin >> std::skipws >> str;
 	}
 
 	return str;
@@ -415,4 +413,7 @@ std::string str(double value) {
 }
 std::string str(long double value) {
 	return std::to_string(value);
+}
+std::string ltrim(std::string str) {
+	return str.erase(0, str.find_first_not_of(' '));
 }

--- a/src/CPipe.h
+++ b/src/CPipe.h
@@ -159,5 +159,6 @@ std::string str(unsigned long long value);
 std::string str(float value);
 std::string str(double value);
 std::string str(long double value);
+std::string ltrim(std::string str);
 
 #endif // CPIPE_H

--- a/src/baumhausengine.cpp
+++ b/src/baumhausengine.cpp
@@ -91,9 +91,9 @@ void CBaumhausengine::startRoutine() {
     			this->random = !this->random;
     		}
     		else if ("usermove" == message) { //quick and dirty way. needs to be made better
-          movePointers (pipe->dequeueInputMessage(true).substr(1, 4));
-          analyzePos();
-          this->colorOnTurn != this->colorOnTurn;
+			  movePointers (pipe->dequeueInputMessage(true).substr(1, 4));
+			  analyzePos();
+			  this->colorOnTurn != this->colorOnTurn;
     			//std::string move = pipe->dequeueInputMessage(true);
     			// validate move
     			// TODO


### PR DESCRIPTION
As the title indicates. Removed the `[OUTPUT]` tag when in debug mode. 
Also fixed trimming input  when reading to end of line.